### PR TITLE
Fix misspelling in syntax example: “hightlight”

### DIFF
--- a/data/syntax.yml
+++ b/data/syntax.yml
@@ -188,7 +188,7 @@
     <h1>{{name}}</h1>
     <p>
       {{intro}}
-      {{hightlight name}}
+      {{highlight name}}
     </p>
 
 


### PR DESCRIPTION
“hightlight” → “highlight”