### PR TITLE
Revised documentation per Emblem 6.1

### DIFF
--- a/data/idioms.yml
+++ b/data/idioms.yml
@@ -7,20 +7,21 @@
   emblem: |
 
     ul
-      each items
-        li Item name: #{name}
+      = each items as |item|
+        li Item name: #{item.name}
 
     / Shorter version:
 
-    ul = each items
-      li Item name: #{name}
+    ul = each items as |item|
+      li Item name: #{item.name}
 
   html: |
     <ul>
-      {{#each items}}
-        <li>Item name: {{name}}
+      {{#each items as |item|}}
+        <li>Item name: {{item.name}}
       {{/each}}
     </ul>
+
 
 -
   title: link-to (Text Content for Block Expressions)
@@ -31,12 +32,14 @@
   emblem: |
 
     / The following three are equivalent
-    = link-to "home"
+    = link-to "home.index"
       | Home
 
-    = link-to "home" | Home
+    = link-to "Home" "home.index"
 
-    link-to "home" | Home
+    = link-to "home.index" | Home
+
+    = link-to "items.list" (query-params page=2) | Go to page 2
 
     ul
       li = link-to "index" | Home
@@ -44,18 +47,25 @@
 
 
   html: |
-    {{#link-to "home"}}Home{{/link-to}}
+    {{#link-to "home.index"}}Home{{/link-to}}
+
+    {{#link-to "items.list" (query-params page=2)}}Go to page 2{{/link-to}}
 
     <ul>
       <li>{{#link-to "index"}}Home{{/link-to}}</li>
       <li>{{#link-to "about"}}About Us{{/link-to}}</li>
     </ul>
 
+
 -
   title: Colon Syntax for Inlining Nested Content
 
   docs: |
     The colon separator is a way of nesting content on a single line. It's essentially an alternative to a newline followed by indented content.
+
+    Whatever comes after a statement-terminating `:` will be interpreted as if it were moved to the line below and indented. This allows you to quickly alternate between nesting HTML elements and mustache blocks on a single line when it makes sense.
+
+    This should come in handy for scaffolding frameworks like Twitter Bootstrap (the first part of the example on the right is Bootstrap scaffolding code).
 
   emblem: |
     / You could write something like this:
@@ -74,10 +84,16 @@
 
     / With colons:
     li: link-to 'posts': span: linkText
-        
+
     / You can consistently use it, even for simple cases.
-    legend: title 
+    legend: title
     legend = title
+
+    / You can nest groups
+    #content-frame: .container: .row
+      .span4: = list-item "sidebar"
+      .span8: = list-item "main"
+
 
 -
   title: HTML Attribute Shorthand for Ember Helpers
@@ -104,36 +120,17 @@
       {{#view Ember.View tagName="span" elementId="the-id" class="some-class"}}Adding a space before % also works.{{/view}}
     </div>
 
--
-  title: each/else
-
-  docs: |
-    This isn't strictly an Emblem pattern, but keep in mind that the `each` helper excepts an optional `else` portion that will be displayed when the list is empty or nonexistent.
-
-  emblem: |
-
-    each things
-      p = name
-    else
-      p There are no things!
-
-  html: |
-    {{#each things}}
-      <p>{{name}}</p>
-    {{else}}
-      <p>There are no things!</p>
-    {{/each}}
 
 -
   title: Ember input helper
 
   docs: |
     Keep in mind that the `input` helper provided by Ember must be used with preceding `=`. If you use it like a normal tag, the `value` will be bound read only and the bound object won't be changed when typing.
-    
+
   emblem: |
 
     input value=name id="noEmberHelper" class="wrong possible-headache"
-    
+
     = input value=name id="withEmberHelper" class="right"
 
   html: |

--- a/data/installation.yml
+++ b/data/installation.yml
@@ -1,3 +1,14 @@
+# Ember CLI
+-
+  title: Ember CLI
+  docs: |
+    [ember-cli-emblem](https://github.com/Vestorly/ember-cli-emblem) will automatically parse any of your Emblem templates with either the `.emblem` or `.embl` extensions into raw handlebars.
+
+    For a new Ember CLI application, you will only need to add the `ember-cli-emblem` addon.  However, if your project includes `broccoli-emblem-compiler`, it should first be removed: `npm uninstall --save-dev broccoli-emblem-compiler`.
+
+  shell: |
+    ember install ember-cli-emblem
+
 # Rails
 -
   title: Ruby on Rails
@@ -71,7 +82,7 @@
   instructions: |
     Follow [these instructions](http://mimosajs.com/started.html) to get started with Mimosa.
 
-    Once you're setup, files ending in .emblem or .embl will be compiled as Emblem templates. If you've enabled Ember in your project, they'll be compiled as Ember-ized templates. 
+    Once you're setup, files ending in .emblem or .embl will be compiled as Emblem templates. If you've enabled Ember in your project, they'll be compiled as Ember-ized templates.
 
 # Ember Tools
 -

--- a/data/syntax.yml
+++ b/data/syntax.yml
@@ -25,6 +25,8 @@
   docs: |
     To wrap one element in another, just indent and place the element below.
 
+    Emblem assumes that indentation is with two spaces.
+
   emblem: |
     footer
       ul
@@ -47,7 +49,9 @@
   docs: |
     CSS classes can added to elements by using a (`.`) with the class name afterwards. You can place this after an element name (`div` is the default tag name).
 
-    You can chain multiple class names.
+    You can chain multiple class names, and Emblem will combine all class definitions into a single `class` HTML5 attribute.
+
+    NOTE: see use of bindings below and the inline if for more complex examples.
 
   emblem: |
     .title Title
@@ -56,12 +60,16 @@
 
     button.btn.btn-large Submit
 
+    div.foo class='bar'
+
   html: |
     <div class="title">Title</div>
 
     <h1 class="logo">Law Blog</h1>
 
     <button class="btn btn-large">Submit</button>
+
+    <div class="foo bar">
 
 
 -
@@ -82,37 +90,6 @@
 
 
 -
-  title: HTML Attributes
-
-  docs: |
-    HTML attributes can be added right after the element, using `key="value"` pairs.
-
-    HTML attributes can also have mustaches embedded in them, though make sure to use the `unbound` helper in an Ember setting. Note the exclamation mark shorthand for setting an HTML attribute to an unbound property in an Ember setting.
-
-  emblem: |
-    button.close data-dismiss="modal" x
-
-    / For Vanilla Handlebars mode only
-    button class="large {{foo}}" x
-
-    / For Ember Handlebars
-    button class="large {{unbound foo}}" x
-
-    / Shorthand for Ember
-    button class=foo! x
-
-
-
-  html: |
-    <button class="close" data-dismiss="dropdown">x</button>
-
-    <button class="large {{foo}}">x</button>
-
-    <button class="large {{unbound foo}}">x</button>
-
-    <button class="{{unbound foo}}">x</button>
-
--
   title: Comments
 
   docs: |
@@ -125,6 +102,7 @@
 
     / A long long
       multiline comment
+
 
 -
   title: Plain Text
@@ -144,9 +122,9 @@
     | Some content
 
     p
-      | Lorem #{link-to 'something' | ipsum} dolor sit amet, consectetur 
-        adipisicing elit, sed do eiusmod tempor incididunt ut labore et 
-        dolore magna aliqua.  Ut enim ad minim veniam, quis nostrud 
+      | Lorem #{link-to 'something' | ipsum} dolor sit amet, consectetur
+        adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua.  Ut enim ad minim veniam, quis nostrud
         exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
     span.name Your name is {{name}}
@@ -159,10 +137,10 @@
     Some content
 
     <p>
-      Lorem {{#link-to something}}ipsum{{/link-to}} dolor sit amet, 
+      Lorem {{#link-to something}}ipsum{{/link-to}} dolor sit amet,
       consectetur adipisicing elit, sed do eiusmod tempor incididunt
-      ut labore et dolore magna aliqua.  Ut enim ad minim veniam, 
-      quis nostrud exercitation ullamco laboris nisi ut aliquip 
+      ut labore et dolore magna aliqua.  Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip
       ex ea commodo consequat.
     </p>
 
@@ -170,11 +148,12 @@
 
     <span>Trailing space </span>
 
+
 -
   title: Handlebars Expressions
 
   docs: |
-    To output a handlebars expression, use `=` before expression.
+    To output a handlebars expression, use `=` before an expression.
 
     NOTE: You have the option to omit the `=` unless the expression begins with a [known HTML5 tag name](https://developer.mozilla.org/en-US/docs/HTML/HTML5/HTML5_element_list).
 
@@ -193,37 +172,97 @@
 
 
 -
-  title: Unescaped Expressions
+  title: HTML Attributes
 
   docs: |
-    By default Handlebars html escapes output from expressions. To include html without escaping, use `==` which will output Handlebars "triple-stash" expressions `{{{}}}`.
+    HTML attributes can be added right after the element using `key="value"` pairs.
+
+    HTML attributes can also have mustaches embedded in them.
+
+    For an HTML element with multiple attribute definitions, to improve readability you can wrap all of them in brackets `[]` and nest them under the element, one definitino per line.
 
   emblem: |
-    body
-      == outlet
+    button.close data-dismiss="modal" x
+
+    button class="large {{foo}}" x
+
+    button [
+      data-hint='Click me for more information'
+      class='info'
+      data-dismiss='modal'
+    ]
 
   html: |
-    <body>
-      {{{outlet}}}
-    </body>
+    <button class="close" data-dismiss="modal">x</button>
+
+    <button class="large {{foo}}">x</button>
+
+    <button data-hint="Click me for more information" class="info" data-dismiss="modal">
+
+
+-
+  title: Attribute Bindings
+
+  ember: true
+
+  docs: |
+    Bound attributes can be added to either an HTML Element or Ember component using `key=value` pairs.
+
+    If you define a bound value for a class, Emblem will combine these with any other class attributes into a single class attribute definition.
+
+    To define a binding as mutable using the Ember `mut` helper, wrap the definition in a single curley `{}`.
+
+    Emblem provides the `!` helper to flag a bound value as unbound.  (NOTE: this feature is not supported in Ember after 1.13).
+
+    NOTE: As of version 6.0, Emblem supports HTMLBars bound attributes, so `bind-attr` is no longer automatically added.
+
+  emblem: |
+    img src=logoUrl alt="Logo"
+
+    div.foo class=activeClass
+
+    = my-form name={ mut model.name }
+
+    button class="large {{unbound foo}}" x
+
+    button class=foo! x
+
+    / Only supported Ember pre 1.13
+    = my-form name={ bind-attr model.name }
+
+
+  html: |
+    <img src={{"logoUrl"}} alt="Logo">
+
+    <div class="foo {{activeClass}}">
+
+    <button class="large {{unbound foo}}">x</button>
+
+    <button class="{{unbound foo}}">x</button>
+
+    <my-form name={{mut model.name}}>
+
+    <my-form name={{bind-attr model.name}}>
 
 
 -
   title: Handlebars Block Helpers
 
   docs: |
-    Handlebars block statements follow a syntax similar to HTML5 elements, in that indented content on the lines below get wrapped in the block form of the helper.
+    Handlebars block statements follow a syntax similar to HTML5 elements.  Indented content on the lines below get wrapped in the block form of the helper.
 
-    To use a block helper with the same name as an HTML5 element, you can explicitly use a handlebars block helper by starting the line with `=`.
+    Block helpers support Ember's block param syntax `as |item index|`.
 
     Block helpers with only text content can be succinctly written on a single line using a `|` pipe to separate the helper code from the text.
 
+    To use a block helper with the same name as an HTML5 element, you can explicitly use a handlebars block helper by starting the line with `=`.
+
   emblem: |
     ul
-      each person in people
+      = each people as |person|
         li = person
 
-    link-to "home" | Link Text
+    = link-to "home" | Link Text
 
     list nav id="nav-bar" class="top"
       a href="url" = title
@@ -231,9 +270,9 @@
     = strong
       = something
 
-    if something
+    = if something
       p Something!
-    else
+    = else
       p Something else!
 
   html: |
@@ -261,85 +300,119 @@
       <p>Something else!</p>
     {{/if}}
 
--
-  title: Condensed Nesting with Colon Separator (NEW)
+
+- title: Conditionals
 
   docs: |
-    You can condense nested HTML or block mustache content into a single line by using `:` to terminate the present element or block mustache declaration.
-
-    Whatever comes after a statement-terminating `:` will be interpreted as if it were moved to the line below and indented. This allows you to quickly alternate between nesting HTML elements and mustache blocks on a single line when it makes sense.
-
-    This should come in handy for scaffolding frameworks like Twitter Bootstrap (the first part of the example on the right is Bootstrap scaffolding code).
+    Conditionals are a subset of block expressions and support all of the Handlebars / Ember expressions (e.g. `else if`, `unless`, `each`, etc.).
 
   emblem: |
-    #content-frame: .container: .row:
-      .span4: render "sidebar"
-      .span8: render "main"
 
-    footer: ul.menu-items: each menu_items: li: a.menu-link href=url: link_text
+    = if isActive
+      .item Active
+    = else
+      .item Inactive
+
+    = unless isActive
+      .item Inactive
+    = else
+      .item Active
+
+    = if firstThing
+      .item First
+    = else if secondThing
+      .item Second
+    = else if otherThing
+      .item
+        = if isBlue
+          p Blue
+        = else
+          p NotBlue
+    = else
+      .item Unknown
 
   html: |
-    <div id="content-frame">
-      <div class="container">
-        <div class="row">
-          <div class="span4">
-            {{render "sidebar"}}
-          </div>
-          <div class="span8">
-            {{render "main"}}
-          </div>
-        </div>
+    {{#if isActive}}
+      <div class="item">Active</div>
+    {{#else}}
+      <div class="item">Inactive</div>
+    {{/if}}
+
+    {{#unless isActive}}
+      <div class="item">Inactive</div>
+    {{#else}}
+      <div class="item">Active</div>
+    {{/if}}
+
+    {{#if firstThing}}
+      <div class="item">First</div>
+    {{#else if secondThing}}
+      <div class="item">Second</div>
+    {{#else if otherThing}}
+      <div class="item">
+        {{#if isBlue}}
+          <p>Blue</p>
+        {{else}}
+          <p>NotBlue</p>
+        {{/if}}
       </div>
-    </div>
-    <footer>
-      <ul class="menu-items">
-        {{#each menu_items}}
-          <li>
-            <!-- of course, in an Ember.js context, href will be set via a bind-attr -->
-            <a class="menu-link" href="{{url}}">{{link_text}}</a>
-          </li>
-        {{/each}}
-      </ul>
-    </footer>
+    {{#else}}
+      <div class="item">Unknown</div>
+    {{/if}}
+
 
 -
-  title: Views
+  title: Components
 
   ember: true
 
   docs: |
-    You can quickly and easily include an Ember.js view by starting a line with a capitalized letter. This will automatically wrap the line with a `{{view}}` helper.
+    You can quickly and easily include an Ember.js component by starting a line with an equals sign and following it with any parameters.
+
+    Components can have block params and blocks.
+
+    As with HTML elements, components  can have their attributes wrapped in brackets `[]` for easier readability.
 
   emblem: |
     .field
-      Ember.TextField valueBinding="firstName"
+      = my-component value='firstName'
+
+    .field
+      ul
+        = each items as |item|
+          = my-component value=item
+
+    = my-list as |list index|
+      = list-item list=list index=index
+
+    = my-component [
+      value='firstName'
+      title='Name'
+      model=model
+      changed=(action 'nameChanged')
+    ]
 
   html: |
     <div class="field">
-      {{view Ember.TextField valueBinding="firstName"}}
+      {{ my-component value="firstName" }}
     </div>
 
--
-  title: bind-attr Shorthand
+    <div class="field">
+      <ul>
+        {{#each items as |item| }}
+          {{ my-component value=item }}
+          {{ my-component value=item }}
+          {{ my-component value=item }}
+        {{/each }}
+      </ul>
+    </div>
 
-  ember: true
+    {{#my-component as |list index}}
+      {{list-item list=list index=index}}
+    {{/my-component}}
 
-  docs: |
-    Emblem.js makes binding expression attributes (via `bind-attr`) clean and simple.
+    {{ my-component value="firstName" title="Name" model=model changed=(action 'nameChanged') }}
 
-  emblem: |
-    img src=logoUrl alt="Logo"
-
-    div class=condition:whenTrue:whenFalse
-
-    div class={ condition1:whenTrue:whenFalse condition2:whenTrue:whenFalse }
-
-  html: |
-    <img {{bind-attr src="logoUrl"}} alt="Logo">
-
-    <div {{bind-attr class="condition:whenTrue:whenFalse"}}></div>
-
-    <div {{bind-attr class="condition1:whenTrue:whenFalse condition2:whenTrue:whenFalse"}}></div>
 
 -
   title: Action / Events Shorthand
@@ -349,60 +422,101 @@
   docs: |
     Like with HTML5 elements, Emblem is aware of common Ember action names, such as `click`, `submit`, `mouseEnter`, etc. When you use these as attributes, they'll be converted to `action` helpers.
 
+    If the action helper is a multi-word string, use the contents of that string exactly.
+
+    Use single quotes `'` to designate an unbound action.
+
+    Emblem also supports the new closure actions released in Ember 1.13.  For more complex action expressions, wrap them in a single curly `{}`.
+
   emblem: |
     a click="toggleHeader" x
 
-    a click="toggleHeader target='view'" x
+    button click="'unboundAction' boundItem"
+    button click="'unboundAction' 'unbountItem'"
 
-    a click="toggleHeader this" x
+    a click="'toggleHeader' target='view'" x
 
-    form submit="submitTheForm foo"
+    form submit="'submitTheForm' foo"
       p Hello
+
+    = my-component itemChanged=(action 'itemChanged')
+
+    = my-form submit={ action (mut model.name) }
+      button
 
   html: |
     <a {{action toggleHeader on="click"}}>x</a>
-    
-    <a {{action toggleHeader on="click" target="view"}}>x</a>
 
-    <a {{action toggleHeader this on="click"}}>x</a>
+    <button {{action 'unboundAction' boundItem on="click"}}></button>
+    <button {{action 'unboundAction' 'unboundItem' on="click"}}></button>
 
-    <form {{action submitTheForm foo on="submit"}}><p>Hello</p></form>
--
-  title: Explicit Attribute Expressions
+    <a {{action 'toggleHeader' on="click" target="view"}}>x</a>
 
+    <form {{action 'submitTheForm' foo on="submit"}}><p>Hello</p></form>
+
+    {{my-component itemChanged=(action 'itemChanged')}}
+
+    <my-form submit={{action (mut model.name)}}></my-component>
+
+
+- title: Inline If
   ember: true
-
   docs: |
-    To use expressions within the element attributes (often used in Ember with `bind-attr` and `action`), use the `{}` syntax after the element.
+    Emblem supports the inline if syntax introduced in Ember 1.11.  Expressions should be wrapped inside a single curley block `{}`.
 
-    Multiple attribute expressions are also supported.
+    Emblem will map any uses of the colon syntax to the inline if syntax.
 
   emblem: |
-    button{action "delete"} Delete
+    div value={ if isTrue 'one' activeItem }
 
-    img{bind-attr src="logoUrl"} alt="logo"
-    a{bind-attr class="isActive"}{action 'toggleHeader'} x
+    div class=condition:whenTrue:whenFalse
+
+    .foo class={ isHovering condition1:whenTrue:whenFalse condition2:whenTrue:whenFalse }
 
   html: |
-    <button {{action "delete"}}>Delete</button>
+    <div value={{if isTrue 'one' activeItem}}
 
-    <img {{bind-attr src="logoUrl"}} alt="logo">
+    <div class="{{if condition 'whenTrue' 'whenFalse'}}"></div>
 
-    <a {{bind-attr class="isActive"}} {{action "toggleHeader"}}>x</a>
+    <div class="foo {{isHovering}} {{if condition1 'whenTrue' 'whenFalse'}} {{if condition2 'whenTrue' 'whenFalse'}}">
+
+
+-
+  title: Unescaped Expressions
+
+  docs: |
+    By default Handlebars html escapes output from expressions. To include html without escaping, use `==` which will output Handlebars "triple-stash" expressions `{{{}}}`.
+
+  emblem: |
+    body
+      == outlet
+
+  html: |
+    <body>
+      {{{outlet}}}
+    </body>
+
 
 -
   title: In-Tag Mustache
 
   docs: |
-    Occasionally, you'll want to put mustache content inside the opening tag of an HTML element. You can do this by immediately following the tag content with curly braces.
-
-    Note: instead of using this for Ember's `bind-attr`, you can use Emblem's `bind-attr` syntax described below in Implicit Bind Attributes.
+    Occasionally, you'll want to add custom mustache, either inside the opening tag of an HTML5 element or as an assignment for an attribute. You can do this by immediately following the tag content with a single curly brace.
 
   emblem: |
     span.some-class{ someHelper } Hello
 
+    button{ action 'delete' } Delete
+
+    button name={ capitalize-string model.name } Delete
+
   html: |
     <span class="some-class" someHelperOutput="foo">Hello</span>
+
+    <button {{action "delete"}}>Delete</button>
+
+    <button name={{capitalize-string model.name}}>
+
 
 -
   title: Vanilla Handlebars Partials
@@ -410,11 +524,11 @@
   docs: |
     To invoke partials with non-Emberized Handlebars, you can use the `>` syntax.
 
-    Note that you'll never really use this for Ember apps; rather, in those cases, you'd use the `partial` helper.
+    Note that you'll never really use this for Ember apps; rather, in those cases, you'd use the `= partial` helper.
 
     Also note that there's no good way to precompile partials other than to precompile them as templates and then run `Handlebars.partials = Handlebars.templates` before any rendering has taken place.
 
-    If you're not precompiling, and you want to directly register an Emblem template, you can use `Emblem.registerPartial`. 
+    If you're not precompiling, and you want to directly register an Emblem template, you can use `Emblem.registerPartial`.
 
   emblem: |
     > partialName

--- a/source/_intro_hack.html.erb
+++ b/source/_intro_hack.html.erb
@@ -13,7 +13,7 @@
 <span class="Comment">  known HTML tag, else invoke HB helper or perform property lookup.</span>
 <span class="Comment">  These defaults are easily overridable when necessary.</span>
 <span class="Entity">ul</span>
-<span class="Keyword">  each </span>person <span class="Keyword">in</span> people
+<span class="Keyword">  each </span>person <span class="Keyword">as</span> |people|
 <span class="Entity">    li </span>= person.name
 
 <span class="Entity">section.ember-features</span>

--- a/source/stylesheets/application.css.sass
+++ b/source/stylesheets/application.css.sass
@@ -140,7 +140,7 @@ body
         pre
           padding: 20px
           margin: 5px 0
-          max-width: 650px
+          max-width: 75%
           overflow: auto
 
         &.emblem


### PR DESCRIPTION
This pull request is to get the documentation mostly up to date with Ember 1.9.x / 2.0 and Emblem 6.1.

The major changes are:
- Instructions for installing with Ember CLI
- Some reorganization of examples and overall flow
- Additional details about new / changed Ember features:
  - deprecation of Ember.View
  - bindings
  - block params
  - actions
  - inline if
  - conditionals 

This pull request also cherry-picks the following pull requests:
- https://github.com/machty/emblem-site/pull/23
- https://github.com/machty/emblem-site/pull/22
- https://github.com/machty/emblem-site/pull/21

There is a lot of room for further refinement, but the goal here was to at least pick of some large pieces since the current site is out of alignment with Ember and Emblem in some significant ways.
