### PR TITLE
Change each .. in .. to each .. as |..|

### DIFF
--- a/data/syntax.yml
+++ b/data/syntax.yml
@@ -220,7 +220,7 @@
 
   emblem: |
     ul
-      each person in people
+      each people as |person|
         li = person
 
     link-to "home" | Link Text
@@ -238,7 +238,7 @@
 
   html: |
     <ul>
-      {{#each person in people}}
+      {{#each people as |person|}}
         <li>{{person}}</li>
       {{/each}}
     </ul>


### PR DESCRIPTION
Syntax `each person in people` doesn't work anymore (Ember 2.8). It took me couple hours to figure this out.

Also, this syntax doesn't work either:
```
each items
  li Item name: #{name}
```
But I'm not sure whether it's problem with ember or handlebars.